### PR TITLE
Unread comment correction

### DIFF
--- a/Trailer/API.m
+++ b/Trailer/API.m
@@ -133,8 +133,9 @@
 						 // check if we're assigned to a just created pull request, in which case we want to "fast forward" its latest comment dates to our own if we're newer
 						 if(p.postSyncAction.integerValue == kPostSyncNoteNew)
 						 {
-							 if(!p.latestReadCommentDate || [p.latestReadCommentDate compare:c.updatedAt]==NSOrderedAscending)
-								 p.latestReadCommentDate = c.updatedAt;
+							 NSDate *commentCreation = c.createdAt;
+							 if(!p.latestReadCommentDate || [p.latestReadCommentDate compare:commentCreation]==NSOrderedAscending)
+								 p.latestReadCommentDate = commentCreation;
 						 }
 					 }
 				 } finalCallback:^(BOOL success, NSInteger resultCode) {

--- a/Trailer/PullRequest.m
+++ b/Trailer/PullRequest.m
@@ -59,7 +59,7 @@
 
 	NSFetchRequest *f = [NSFetchRequest fetchRequestWithEntityName:@"PRComment"];
 	NSNumber *localUserId = @([Settings shared].localUserId.longLongValue);
-	f.predicate = [NSPredicate predicateWithFormat:@"pullRequestUrl == %@ and updatedAt > %@ and userId != %@",
+	f.predicate = [NSPredicate predicateWithFormat:@"pullRequestUrl == %@ and createdAt > %@ and userId != %@",
 				   self.url,
 				   self.latestReadCommentDate,
 				   localUserId];
@@ -157,10 +157,10 @@
 	NSArray *res = [self.managedObjectContext executeFetchRequest:f error:nil];
 	for(PRComment *c in res)
 	{
-		if(!self.latestReadCommentDate) self.latestReadCommentDate = c.updatedAt;
-		else if([self.latestReadCommentDate compare:c.updatedAt]==NSOrderedAscending)
+		NSDate *commentCreation = c.createdAt;
+		if(!self.latestReadCommentDate || [self.latestReadCommentDate compare:commentCreation]==NSOrderedAscending)
 		{
-			self.latestReadCommentDate = c.updatedAt;
+			self.latestReadCommentDate = commentCreation;
 		}
 	}
 	[self postProcess];


### PR DESCRIPTION
GitHub may touch comment records for reasons other than editing the comments, which ends up giving false/invalid unread count badges.  Using the created_at attribute instead of the updated_at one fixes this issue.
