### PR TITLE
Fix blurry avatars by fetching at bigger size

### DIFF
--- a/Trailer/AppDelegate.m
+++ b/Trailer/AppDelegate.m
@@ -476,7 +476,7 @@ static AppDelegate *_static_shared_ref;
 	{
 		PRComment *c = (PRComment *)item;
 		[self.api haveCachedImage:c.avatarUrl
-						  forSize:CGSizeMake(AVATAR_SIZE, AVATAR_SIZE)
+						  forSize:CGSizeMake(NOTIFICATION_AVATAR_SIZE, NOTIFICATION_AVATAR_SIZE)
 			   tryLoadAndCallback:^(NSImage *image) {
 				   notification.contentImage = image;
 				   [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];

--- a/Trailer/PRComment.m
+++ b/Trailer/PRComment.m
@@ -28,7 +28,7 @@
 		NSDictionary *userInfo = [info ofk:@"user"];
 		c.userName = [userInfo ofk:@"userName"];
 		c.userId = [userInfo ofk:@"id"];
-		c.avatarUrl = [userInfo ofk:@"avatar_url"];
+		c.avatarUrl = [(NSString *)[userInfo ofk:@"avatar_url"] stringByAppendingFormat:@"s=%.f", NOTIFICATION_AVATAR_SIZE];
 
 		NSDictionary *links = [info ofk:@"links"];
 		c.url = [[links ofk:@"self"] ofk:@"href"];

--- a/Trailer/PRItemView.h
+++ b/Trailer/PRItemView.h
@@ -1,5 +1,6 @@
 
 #define AVATAR_SIZE 26.0
+#define NOTIFICATION_AVATAR_SIZE 88.0
 #define LEFTPADDING 44.0
 
 #define PR_ITEM_FOCUSED_NOTIFICATION_KEY @"PrItemFocusedNotificationKey"

--- a/Trailer/PullRequest.m
+++ b/Trailer/PullRequest.m
@@ -59,7 +59,7 @@ static NSDateFormatter *itemDateFormatter;
 		NSDictionary *userInfo = [info ofk:@"user"];
 		p.userId = [userInfo ofk:@"id"];
 		p.userLogin = [userInfo ofk:@"login"];
-		p.userAvatarUrl = [userInfo ofk:@"avatar_url"];
+		p.userAvatarUrl = [(NSString *)[userInfo ofk:@"avatar_url"] stringByAppendingFormat:@"s=%.f", NOTIFICATION_AVATAR_SIZE];
 
 		p.repoId = [[[info ofk:@"base"] ofk:@"repo"] ofk:@"id"];
 


### PR DESCRIPTION
Instead of fetching the images at 26x26, it's fetching at 88x88. (the
image in a notification seems to be 44x44, so 88x88 should cover the
case of Retina displays)

That would mean that the cache should end up with more stuff in it since
it'd get the avatars from the notifications at 88x88 and the avatar for
the dropdown menu at 26x26... Not sure of the best way to do it though.

Hope that helps.
