### PR TITLE
Update homepage references from Housetrip to Paul Tsochantaris

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,14 +7,14 @@
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="description" content="Trailer.app keeps your GitHub pull requests on track.">
     <meta name="keywords" content="Trailer.app, trailer, pull request, github pull request">
-    <meta name="author" content="HouseTrip">
+    <meta name="author" content="Paul Tsochantaris">
 
     <meta property="og:description" content="Trailer.app keeps your GitHub pull requests on track." />
     <meta property="og:site_name" content="Trailer.app" />
     <meta property="og:title" content="Trailer.app - Keep your GitHub Pull Requests on track." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="http://dev.housetrip.com/trailer" />
-    <meta property="og:image" content="http://dev.housetrip.com/trailer/images/Icon256.png" />
+    <meta property="og:url" content="https://github.com/ptsochantaris/trailer" />
+    <meta property="og:image" content="http://ptsochantaris.github.io/trailer/images/Icon256.png" />
 
     <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="css/bootstrap-theme.min.css" media="screen" />
@@ -48,12 +48,12 @@
       <div class="row call-to-action">
         <div class="col-xs-12">
           <div class="text-center">
-            <a href="http://dev.housetrip.com/trailer/trailer113.zip" class="btn btn-primary btn-lg" role="button">
+            <a href="https://github.com/ptsochantaris/trailer/trailer113.zip" class="btn btn-primary btn-lg" role="button">
               <span class="glyphicon glyphicon-cloud-download"></span>
               Download
             </a>
 
-            <a href="https://github.com/HouseTrip/trailer" class="btn btn-primary btn-lg" role="button" target="_blank">
+            <a href="https://github.com/ptsochantaris/trailer" class="btn btn-primary btn-lg" role="button" target="_blank">
               <span class="glyphicon glyphicon-link"></span>
               On GitHub
             </a>
@@ -102,9 +102,11 @@
             </li>
           </ul>
 
+          <!--
           <div class="housetrip">
             <p class="large">Brought to you by <a href="http://dev.housetrip.com/" target="_blank">HouseTrip</a>.</p>
           </div>
+          -->
         </div>
       </div>
     </div>


### PR DESCRIPTION
The homepage at `http://ptsochantaris.github.io/trailer/` refers in various places to `Housetrip` and `http://dev.housetrip.com/trailer/`which no longer exists, and, most importantly, has a broken download link. This PR updates the various links and text to replace those references, and fix the link.

Some things I've left alone as I'm not sure what to replace them with. Therefore I've commented out the `Brought to you by` section, and just left the Google Analytics section as is.
