### PR TITLE
fix crash in status items filter

### DIFF
--- a/Trailer/PullRequest.m
+++ b/Trailer/PullRequest.m
@@ -468,19 +468,22 @@ static NSDateFormatter *itemDateFormatter;
 		NSArray *terms = settings.statusFilteringTerms;
 		if(terms.count)
 		{
-			NSMutableArray *ors = [NSMutableArray arrayWithCapacity:terms.count];
+			NSMutableArray *subpredicates = [NSMutableArray arrayWithCapacity:terms.count];
 			for(NSString *term in terms)
 			{
-				[ors addObject:[NSString stringWithFormat:@"descriptionText contains[cd] '%@'", term]];
+				[subpredicates addObject:[NSPredicate predicateWithFormat:@"descriptionText contains[cd] %@", term]];
 			}
+			NSPredicate *orPredicate = [NSCompoundPredicate orPredicateWithSubpredicates:subpredicates];
+			NSPredicate *selfPredicate = [NSPredicate predicateWithFormat:@"pullRequest == %@", self];
 
 			if(mode==kStatusFilterInclude)
 			{
-				f.predicate = [NSPredicate predicateWithFormat:@"pullRequest == %@ and (%@)", self, [ors componentsJoinedByString:@" or "]];
+				f.predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[selfPredicate, orPredicate]];
 			}
 			else
 			{
-				f.predicate = [NSPredicate predicateWithFormat:@"pullRequest == %@ and (not (%@))", self, [ors componentsJoinedByString:@" or "]];
+				NSPredicate *notOrPredicate = [NSCompoundPredicate notPredicateWithSubpredicate:orPredicate];
+				f.predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[selfPredicate, notOrPredicate]];
 			}
 		}
 		else


### PR DESCRIPTION
App will crash (or no status bar icon shown) if status filter is enabled.
Fixes bug in commit: fbe323c87d49

```
2014/11/14 11:03:10.989 Trailer[1976]: *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'Unable to parse the format string "pullRequest == %@ and (not (%@))"'
*** First throw call stack:
(
    0   CoreFoundation                      0x00007fff8a96525c __exceptionPreprocess + 172
    1   libobjc.A.dylib                     0x00007fff8c67ae75 objc_exception_throw + 43
    2   Foundation                          0x00007fff942394b4 _qfqp2_performParsing + 338
    3   Foundation                          0x00007fff942392f6 +[NSPredicate predicateWithFormat:arguments:] + 46
    4   Foundation                          0x00007fff942392b0 +[NSPredicate predicateWithFormat:] + 142
    5   Trailer                             0x00000001042ceadb Trailer + 117467
    6   Trailer                             0x00000001042cf8ee Trailer + 121070
    7   Trailer                             0x00000001042d85b2 Trailer + 157106
    8   Trailer                             0x00000001042dea15 Trailer + 182805
    9   Trailer                             0x00000001042de1d8 Trailer + 180696
    10  Trailer                             0x00000001042de57a Trailer + 181626
    11  Trailer                             0x00000001042bacc8 Trailer + 36040
    12  Trailer                             0x00000001042c118f Trailer + 61839
    13  libdispatch.dylib                   0x00007fff8a7a81bb _dispatch_call_block_and_release + 12
    14  libdispatch.dylib                   0x00007fff8a7a528d _dispatch_client_callout + 8
    15  libdispatch.dylib                   0x00007fff8a7acef0 _dispatch_main_queue_callback_4CF + 333
    16  CoreFoundation                      0x00007fff8a8cc4f9 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9
    17  CoreFoundation                      0x00007fff8a887714 __CFRunLoopRun + 1636
    18  CoreFoundation                      0x00007fff8a886e75 CFRunLoopRunSpecific + 309
    19  HIToolbox                           0x00007fff8fbbaa0d RunCurrentEventLoopInMode + 226
    20  HIToolbox                           0x00007fff8fbba7b7 ReceiveNextEventCommon + 479
    21  HIToolbox                           0x00007fff8fbba5bc _BlockUntilNextEventMatchingListInModeWithFilter + 65
    22  AppKit                              0x00007fff8d19124e _DPSNextEvent + 1434
    23  AppKit                              0x00007fff8d19089b -[NSApplication nextEventMatchingMask:untilDate:inMode:dequeue:] + 122
    24  AppKit                              0x00007fff8d18499c -[NSApplication run] + 553
    25  AppKit                              0x00007fff8d16f783 NSApplicationMain + 940
    26  libdyld.dylib                       0x00007fff8ced95fd start + 1
)
```

Thanks for great app!
