### PR TITLE
Fix misspelled `status` in Preferences

### DIFF
--- a/Trailer/PreferencesWindow.xib
+++ b/Trailer/PreferencesWindow.xib
@@ -1319,7 +1319,7 @@ to a higher number in order to keep your API usage reasonable</string>
                                                         <rect key="frame" x="17" y="124" width="306" height="18"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                         <animations/>
-                                                        <buttonCell key="cell" type="check" title="Hide PRs whose statuss items are not all green" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="cw8-e1-f8e">
+                                                        <buttonCell key="cell" type="check" title="Hide PRs whose status items are not all green" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="cw8-e1-f8e">
                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                             <font key="font" metaFont="system"/>
                                                         </buttonCell>


### PR DESCRIPTION
"Hide PRs whose status items are not all green"