### PR TITLE
Fix casing of 'GitHub' in user interfaces

### DIFF
--- a/PRIVACY
+++ b/PRIVACY
@@ -7,18 +7,18 @@ beyond that.
 API Key
 
 Trailer and PocketTrailer require your generated API key in
-order to create API calls to Github and fetch your data, as well
-as optional URLs for using Enterprise Github API servers.  This
+order to create API calls to GitHub and fetch your data, as well
+as optional URLs for using Enterprise GitHub API servers.  This
 info is stored locally on your device and never sent or otherwise
 processed in any way, beyond being used inside the locally
-executing app to construct the required API calls to Github.
+executing app to construct the required API calls to GitHub.
 
-Github Login
+GitHub Login
 
 PocketTrailer, specifically, displays an inline web-view
 where you can directly browse your PRs inside the app.  In
 order to view your PRs you may need to provide login
-information to Github's web interface.  This is done directly
+information to GitHub's web interface.  This is done directly
 inside the web-view and PocketTrailer never reads, intercepts, or
 stores any of that information, beyond what may be done at a
 lower level by the system web view control, to which

--- a/PocketTrailer/DetailViewController.swift
+++ b/PocketTrailer/DetailViewController.swift
@@ -92,7 +92,7 @@ final class DetailViewController: UIViewController, WKNavigationDelegate {
 	func webView(webView: WKWebView, decidePolicyForNavigationResponse navigationResponse: WKNavigationResponse, decisionHandler: (WKNavigationResponsePolicy) -> Void) {
 		let res = navigationResponse.response as! NSHTTPURLResponse
 		if res.statusCode == 404 {
-			showMessage("Not Found", "\nPlease ensure you are logged in with the correct account on GitHub\n\nIf you are using two-factor auth: There is a bug between Github and iOS which may cause your login to fail.  If it happens, temporarily disable two-factor auth and log in from here, then re-enable it afterwards.  You will only need to do this once.")
+			showMessage("Not Found", "\nPlease ensure you are logged in with the correct account on GitHub\n\nIf you are using two-factor auth: There is a bug between GitHub and iOS which may cause your login to fail.  If it happens, temporarily disable two-factor auth and log in from here, then re-enable it afterwards.  You will only need to do this once.")
 		}
 		decisionHandler(WKNavigationResponsePolicy.Allow)
 	}

--- a/PocketTrailer/QuickStartViewController.swift
+++ b/PocketTrailer/QuickStartViewController.swift
@@ -73,7 +73,7 @@ final class QuickStartViewController: UIViewController, UITextFieldDelegate {
 			if newServer.lastSyncSucceeded?.boolValue ?? false {
                 dismissViewControllerAnimated(true, completion: {
                     popupManager.getMasterController().updateTabBarVisibility(true)
-					showMessage("Setup complete!", "You can tweak options & behaviour from the settings.\n\nPocketTrailer only has read-only access to your Github data, so feel free to experiment, you can't damage your data or settings on GitHub.")
+					showMessage("Setup complete!", "You can tweak options & behaviour from the settings.\n\nPocketTrailer only has read-only access to your GitHub data, so feel free to experiment, you can't damage your data or settings on GitHub.")
                 })
 			} else {
 				showMessage("Syncing with this server failed - please check that your network connection is working and that you have pasted your token correctly", nil)

--- a/PocketTrailer/iOS_AppDelegate.swift
+++ b/PocketTrailer/iOS_AppDelegate.swift
@@ -213,7 +213,7 @@ final class iOS_AppDelegate: UIResponder, UIApplicationDelegate {
 					return
 				} else if ((apiServer.requestsRemaining?.doubleValue ?? 0.0) / (apiServer.requestsLimit?.doubleValue ?? 1.0)) < LOW_API_WARNING {
 					showMessage((apiServer.label ?? "Untitled Server's") + " API request usage is close to full",
-						"Try to make fewer manual refreshes, increasing the automatic refresh time, or reducing the number of repos you are monitoring.\n\nYour allowance will be reset by Github on \(apiServer.resetDate).\n\nYou can check your API usage from the bottom of the preferences pane.")
+						"Try to make fewer manual refreshes, increasing the automatic refresh time, or reducing the number of repos you are monitoring.\n\nYour allowance will be reset by GitHub on \(apiServer.resetDate).\n\nYou can check your API usage from the bottom of the preferences pane.")
 				}
 			}
 		}
@@ -277,7 +277,7 @@ final class iOS_AppDelegate: UIResponder, UIApplicationDelegate {
 				}
 
 				if !success && UIApplication.sharedApplication().applicationState==UIApplicationState.Active {
-					showMessage("Refresh failed", "Loading the latest data from Github failed")
+					showMessage("Refresh failed", "Loading the latest data from GitHub failed")
 				}
 
 				s.refreshTimer = NSTimer.scheduledTimerWithTimeInterval(NSTimeInterval(Settings.refreshPeriod), target: s, selector: #selector(iOS_AppDelegate.refreshTimerDone), userInfo: nil, repeats:false)
@@ -377,4 +377,3 @@ final class iOS_AppDelegate: UIResponder, UIApplicationDelegate {
 		}
 	}
 }
-

--- a/Trailer/AboutWindow.xib
+++ b/Trailer/AboutWindow.xib
@@ -104,7 +104,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
                     <button verticalHuggingPriority="750" id="5YY-r2-RiE">
                         <rect key="frame" x="270" y="6" width="172" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="push" title="Trailer on Github" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="EI4-JQ-Wj7">
+                        <buttonCell key="cell" type="push" title="Trailer on GitHub" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="EI4-JQ-Wj7">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>

--- a/Trailer/OSX_AppDelegate.swift
+++ b/Trailer/OSX_AppDelegate.swift
@@ -722,7 +722,7 @@ final class OSX_AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, 
 
 					let alert = NSAlert()
 					alert.messageText = "Your API request usage for '\(apiLabel)' is close to full"
-					alert.informativeText = "Try to make fewer manual refreshes, increasing the automatic refresh time, or reducing the number of repos you are monitoring.\n\nYour allowance will be reset by Github \(resetDateString).\n\nYou can check your API usage from the 'Servers' preferences pane at any time."
+					alert.informativeText = "Try to make fewer manual refreshes, increasing the automatic refresh time, or reducing the number of repos you are monitoring.\n\nYour allowance will be reset by GitHub \(resetDateString).\n\nYou can check your API usage from the 'Servers' preferences pane at any time."
 					alert.addButtonWithTitle("OK")
 					alert.runModal()
 				}

--- a/Trailer/PreferencesWindow.xib
+++ b/Trailer/PreferencesWindow.xib
@@ -155,7 +155,7 @@
                                                     <button verticalHuggingPriority="750" id="ifm-A1-rdj">
                                                         <rect key="frame" x="262" y="7" width="192" height="32"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                        <buttonCell key="cell" type="push" title="Reset to Github Defaults" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="zqK-DJ-JcO">
+                                                        <buttonCell key="cell" type="push" title="Reset to GitHub Defaults" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="zqK-DJ-JcO">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="system"/>
                                                         </buttonCell>

--- a/Trailer/SetupAssistant.swift
+++ b/Trailer/SetupAssistant.swift
@@ -100,7 +100,7 @@ final class SetupAssistant: NSWindow, NSWindowDelegate {
 				close()
 				let alert = NSAlert()
 				alert.messageText = "Setup complete!"
-				alert.informativeText = "You can tweak settings & behaviour from the preferences window.\n\nTrailer only has read-only access to your Github data, so feel free to experiment, you can't damage your data or settings on GitHub."
+				alert.informativeText = "You can tweak settings & behaviour from the preferences window.\n\nTrailer only has read-only access to your GitHub data, so feel free to experiment, you can't damage your data or settings on GitHub."
 				alert.addButtonWithTitle("OK")
 				alert.runModal()
 			} else {


### PR DESCRIPTION
Minor edit. The official company name is `GitHub` with the capital `H`.