### PR TITLE
Fix existing tokens URL

### DIFF
--- a/PocketTrailer/ServerDetailViewController.swift
+++ b/PocketTrailer/ServerDetailViewController.swift
@@ -126,7 +126,7 @@ final class ServerDetailViewController: UIViewController, UITextFieldDelegate {
 	}
 
 	@IBAction func existingTokensSelected(_ sender: UIBarButtonItem) {
-		openGitHub(url: "/settings/applications")
+		openGitHub(url: "/settings/tokens")
 	}
 
 	private var validatedPath: URL? {

--- a/Trailer/PreferencesWindow.swift
+++ b/Trailer/PreferencesWindow.swift
@@ -960,7 +960,7 @@ final class PreferencesWindow : NSWindow, NSWindowDelegate, NSTableViewDelegate,
 		if apiServerWebPath.stringValue.isEmpty {
 			reportNeedFrontEnd()
 		} else {
-			let address = "\(apiServerWebPath.stringValue)/settings/applications"
+			let address = "\(apiServerWebPath.stringValue)/settings/tokens"
 			NSWorkspace.shared().open(URL(string: address)!)
 		}
 	}


### PR DESCRIPTION
Hi, thank you for cool iOS app.  I'm using this on iOS and WatchOS 😄 

Currently 'My Tokens' button navigates to https://github.com/settings/applications.
But actually I think that it's better to navigate to https://github.com/settings/tokens because it should show the list of existing tokens.

So I modified the URL to navigate users to more proper URL.