### PR TITLE
Master

### DIFF
--- a/Shared/ListableItem.swift
+++ b/Shared/ListableItem.swift
@@ -13,6 +13,7 @@ class ListableItem: DataItem {
 	@NSManaged var assigneeName: String? // note: This now could be a list of names, delimited with a ","
 	@NSManaged var body: String?
 	@NSManaged var webUrl: String?
+    @NSManaged var shorthandReference: String?
 	@NSManaged var condition: Int64
 	@NSManaged var isNewAssignment: Bool
 	@NSManaged var repo: Repo
@@ -44,6 +45,10 @@ class ListableItem: DataItem {
 		self.repo = repo
 
 		url = info["url"] as? String
+        
+        shorthandReference = (repo.fullName ?? "") + "#" + String(info["number"] as? Int64 ?? 0)
+        
+        
 		webUrl = info["html_url"] as? String
 		number = info["number"] as? Int64 ?? 0
 		state = info["state"] as? String

--- a/Shared/Trailer.xcdatamodeld/Trailer 32.xcdatamodel/contents
+++ b/Shared/Trailer.xcdatamodeld/Trailer 32.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="11759" systemVersion="16C67" minimumToolsVersion="Xcode 8.0" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="11759" systemVersion="16B2548a" minimumToolsVersion="Xcode 8.0" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ApiServer" representedClassName="Trailer.ApiServer" syncable="YES">
         <attribute name="apiPath" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="authToken" optional="YES" attributeType="String" syncable="YES"/>
@@ -49,6 +49,7 @@
         <attribute name="reopened" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="sectionIndex" optional="YES" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="serverId" optional="YES" attributeType="Integer 64" usesScalarValueType="YES" indexed="YES" syncable="YES"/>
+        <attribute name="shorthandReference" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="snoozeUntil" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="state" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
@@ -212,7 +213,7 @@
     <elements>
         <element name="ApiServer" positionX="9" positionY="153" width="128" height="360"/>
         <element name="CacheEntry" positionX="9" positionY="153" width="128" height="150"/>
-        <element name="Issue" positionX="9" positionY="153" width="128" height="540"/>
+        <element name="Issue" positionX="9" positionY="153" width="128" height="555"/>
         <element name="PRComment" positionX="0" positionY="0" width="128" height="225"/>
         <element name="PRLabel" positionX="9" positionY="153" width="128" height="195"/>
         <element name="PRStatus" positionX="0" positionY="0" width="128" height="180"/>

--- a/Trailer.xcodeproj/project.pbxproj
+++ b/Trailer.xcodeproj/project.pbxproj
@@ -950,7 +950,7 @@
 					};
 					168BC6A917EC2DF000BC4584 = {
 						LastSwiftMigration = 0800;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.Mac = {
 								enabled = 1;
@@ -1513,7 +1513,7 @@
 				CODE_SIGN_ENTITLEMENTS = Trailer/Trailer.entitlements;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = X727JSJUGJ;
+				DEVELOPMENT_TEAM = ND555G7AYA;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Trailer",
@@ -1532,9 +1532,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Trailer/Trailer.entitlements;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = X727JSJUGJ;
+				DEVELOPMENT_TEAM = ND555G7AYA;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Trailer",

--- a/Trailer/TrailerCell.swift
+++ b/Trailer/TrailerCell.swift
@@ -115,7 +115,7 @@ class TrailerCell: NSTableCellView {
 		let c1 = m.addItem(withTitle: "Copy URL", action: #selector(copyToClipboard), keyEquivalent: "c")
 		c1.keyEquivalentModifierMask = [.command]
         
-        let c2 = m.addItem(withTitle: "Copy Shorthand Reference", action: #selector(copyshorthandReferenceToClipboard), keyEquivalent: "s")
+        let c2 = m.addItem(withTitle: "Copy Issue Reference", action: #selector(copyshorthandReferenceToClipboard), keyEquivalent: "s")
         c2.keyEquivalentModifierMask = [.command]
 
 

--- a/Trailer/TrailerCell.swift
+++ b/Trailer/TrailerCell.swift
@@ -74,6 +74,15 @@ class TrailerCell: NSTableCellView {
 		}
 	}
 
+    func copyshorthandReferenceToClipboard() {
+        if let s = associatedDataItem?.shorthandReference {
+            let p = NSPasteboard.general()
+            p.clearContents()
+            p.declareTypes([NSStringPboardType], owner: self)
+            p.setString(s, forType: NSStringPboardType)
+        }
+    }
+
 	func copyNumberToClipboard() {
 		if let s = associatedDataItem?.number {
 			let p = NSPasteboard.general()
@@ -105,9 +114,13 @@ class TrailerCell: NSTableCellView {
 		
 		let c1 = m.addItem(withTitle: "Copy URL", action: #selector(copyToClipboard), keyEquivalent: "c")
 		c1.keyEquivalentModifierMask = [.command]
+        
+        let c2 = m.addItem(withTitle: "Copy Shorthand Reference", action: #selector(copyshorthandReferenceToClipboard), keyEquivalent: "s")
+        c2.keyEquivalentModifierMask = [.command]
 
-		let c2 = m.addItem(withTitle: "Open Repo", action: #selector(openRepo), keyEquivalent: "o")
-		c2.keyEquivalentModifierMask = [.command]
+
+		let c3 = m.addItem(withTitle: "Open Repo", action: #selector(openRepo), keyEquivalent: "o")
+		c3.keyEquivalentModifierMask = [.command]
 
 		if item.snoozeUntil == nil {
 			if item.unreadComments > 0 {


### PR DESCRIPTION
Hi,

Thought I’d help out with this tweak. 

Adds a new button in context menu called “Copy Issue Reference”, then copies to clipboard something like:

“owner/repo#number”

Very useful for quick reference

It needs a little more work to ensure existing issues take advantage of it, it only works on newly synced issues. I don’t write in Swift so this is as far as I could take it without my head exploding