### PR TITLE
Fix a typo in "disable" word in the UI

### DIFF
--- a/PocketTrailer/AdvancedSettingsViewController.swift
+++ b/PocketTrailer/AdvancedSettingsViewController.swift
@@ -419,9 +419,9 @@ final class AdvancedSettingsViewController: UITableViewController, PickerViewCon
 		case SettingsSection.Filtering.title:
 			return buildFooter("You can also use title: server: label: repo: user: number: milestone: assignee: and status: to filter specific properties, e.g. \"label:bug,suggestion\". Prefix with '!' to exclude some terms.")
 		case SettingsSection.Reviews.title:
-			return buildFooter("To disble usage of the Reviews API, uncheck all options above and set the moving option to \"Don't Move It\".")
+			return buildFooter("To disable usage of the Reviews API, uncheck all options above and set the moving option to \"Don't Move It\".")
 		case SettingsSection.Reactions.title:
-			return buildFooter("To completely disble all usage of the Reactions API, uncheck all above options.")
+			return buildFooter("To completely disable all usage of the Reactions API, uncheck all above options.")
 		default:
 			return nil
 		}

--- a/Trailer/PreferencesWindow.xib
+++ b/Trailer/PreferencesWindow.xib
@@ -1330,7 +1330,7 @@ Token</string>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" id="PC0-Di-dZ3">
                                                         <rect key="frame" x="-2" y="2" width="554" height="17"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="To disble usage of the Reviews API, uncheck all options here &amp; set the drop-down option to &quot;Don't Move It&quot;" id="bis-lC-jvI">
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="To disable usage of the Reviews API, uncheck all options here &amp; set the drop-down option to &quot;Don't Move It&quot;" id="bis-lC-jvI">
                                                             <font key="font" metaFont="miniSystem"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -1367,7 +1367,7 @@ Token</string>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" id="hYX-l4-6Qc">
                                                         <rect key="frame" x="108" y="94" width="564" height="17"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="To completely disble all usage of the Reactions API, uncheck all options." id="zca-XG-6Sh">
+                                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="To completely disable all usage of the Reactions API, uncheck all options." id="zca-XG-6Sh">
                                                             <font key="font" metaFont="miniSystem"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
There were two occurences of "disble" word on Reviews and Reactions
pages in the settings.

<img width="646" alt="screenshot_19_12_2017__18_57" src="https://user-images.githubusercontent.com/481078/34166096-17b19b10-e4ef-11e7-8638-f9bbb24b9ea9.png">

<img width="635" alt="screenshot_19_12_2017__18_57" src="https://user-images.githubusercontent.com/481078/34166126-27fc30ca-e4ef-11e7-8e81-34e7c250de4e.png">


