### PR TITLE
macOS: fixes a typo in the UI.

### DIFF
--- a/Shared/API.swift
+++ b/Shared/API.swift
@@ -1634,7 +1634,7 @@ final class API {
 				shouldRetry = (code == 502 || code == 503) // retry in case GH is deploying
 				done()
 			} else if code == 0 {
-				error = apiError("Server did not repond")
+				error = apiError("Server did not respond")
 				shouldRetry = (e as NSError?)?.code == -1001 // retry if it was a timeout
 				done()
 			} else if Int64(data?.count ?? 0) < (response?.expectedContentLength ?? 0) {


### PR DESCRIPTION
Attempting to connect to a wrong API path within the Preferences | Servers dialog causes Trailer.app to alert the user with the message _„Server did not repond“_, instead of _„Server did not respond“_. This pull request, if applied, will fix that typo.

![screen shot 2018-05-24 at 17 34 10](https://user-images.githubusercontent.com/28745111/40499152-f30c94cc-5f78-11e8-9c52-334d6f181d25.jpg)