### PR TITLE
[ISSUE-495]: Fix access data permission prompt and Core Data crash during setup

### DIFF
--- a/Trailer/Info.plist
+++ b/Trailer/Info.plist
@@ -54,6 +54,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Trailer needs to check if other applications are running to manage its launcher helper and to open URLs in your preferred applications.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright (c) 2014-2022 Paul Tsochantaris. Parts copyright (c) 2013-2014 HouseTrip Ltd. Released under the terms of the MIT licence, see the file LICENCE for details.</string>
 	<key>NSMainNibFile</key>

--- a/Trailer/SetupAssistant.swift
+++ b/Trailer/SetupAssistant.swift
@@ -12,7 +12,10 @@ final class SetupAssistant: NSWindow, NSWindowDelegate, NSControlTextEditingDele
     @IBOutlet private var welcomeLabel: NSTextField!
     @IBOutlet private var importButton: NSButton!
 
-    private let newServer = ApiServer.allApiServers(in: DataManager.main).first!
+    private lazy var newServer: ApiServer = {
+        ApiServer.ensureAtLeastGithub(in: DataManager.main)
+        return ApiServer.allApiServers(in: DataManager.main).first!
+    }()
 
     @MainActor
     override func awakeFromNib() {
@@ -133,6 +136,8 @@ final class SetupAssistant: NSWindow, NSWindowDelegate, NSControlTextEditingDele
         completeSetup.isHidden = true
         welcomeLabel.isHidden = true
         importButton.isHidden = true
+        // Save the server to Core Data first to get a permanent object ID
+        try! DataManager.main.save()
         newServer.authToken = tokenHolder.stringValue.trim
         newServer.lastSyncSucceeded = true
     }

--- a/TrailerLauncher/Info.plist
+++ b/TrailerLauncher/Info.plist
@@ -26,6 +26,8 @@
 	<true/>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Trailer Launcher needs to check if the main Trailer application is running to manage the application lifecycle.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2014-2022 Paul Tsochantaris. All rights reserved.</string>
 	<key>NSPrincipalClass</key>

--- a/TrailerLauncher/TrailerLauncher.entitlements
+++ b/TrailerLauncher/TrailerLauncher.entitlements
@@ -8,6 +8,8 @@
 	<array>
 		<string>group.Trailer</string>
 	</array>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
 </dict>


### PR DESCRIPTION
Fixes #495

## Primary Fix: Access Data Permission Prompt

The "access data" permission prompt was appearing because:
- Trailer uses Apple Events to communicate between the main app and its launcher helper
- macOS requires explicit permission declarations for Apple Events access

Without proper `NSAppleEventsUsageDescription` entries, the system shows a generic "access data" prompt.
These changes provide clear, user-friendly explanations for why the app needs Apple Events access, replacing the confusing generic permission prompt with proper context.

The launcher also needs `com.apple.security.automation.apple-events` entitlement for automation permissions

## Secondary Fix: Core Data Crash in SetupAssistant

While testing the permission fix, discovered and fixed a crash in `SetupAssistant.swift` that occurred during server setup:

The app crashed with `assert(!objectID.isTemporaryID)` when trying to set auth tokens on newly created ApiServer objects.

### Solution:

Ensures the server has a permanent Core Data object ID before setting the auth token, preventing the assertion failure.

## Test

Started from Trailer 1.8.14 (current main a9d235366f2c6b8e31e81fc63f2e6d2f0d591b46) on Mac Sequoia 15.6
